### PR TITLE
Deprecated include begin-end. Fix smth q_shared

### DIFF
--- a/source/botlib/botlib.vcxproj
+++ b/source/botlib/botlib.vcxproj
@@ -129,6 +129,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
+      <AdditionalOptions>/W4 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_Debug;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/source/cgame/JK2_cgame.vcxproj
+++ b/source/cgame/JK2_cgame.vcxproj
@@ -210,7 +210,9 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
-      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <AdditionalOptions>/W4 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_Debug;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/source/cgame/cg_draw.c
+++ b/source/cgame/cg_draw.c
@@ -162,7 +162,7 @@ char *showPowersName[] =
 };
 
 //Called from UI shared code. For now we'll just redirect to the normal anim load function.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 
 int UI_ParseAnimationFile(const char *filename, animation_t *animset, qboolean isHumanoid) 
@@ -184,7 +184,7 @@ int MenuFontToHandle(int iMenuFont)
 	return cgDC.Assets.qhMediumFont;
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 int CG_Text_Width(const char *text, float scale, int iMenuFont) 
 {

--- a/source/cgame/cg_ents.c
+++ b/source/cgame/cg_ents.c
@@ -843,9 +843,9 @@ void CG_G2ServerBoneAngles(centity_t *cent);
 extern void CG_BodyQueueCopy(centity_t *cent, int clientNum, int knownWeapon);
 //[/NOBODYQUE]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_GetRootSurfNameWithVariant( void *ghoul2, const char *rootSurfName, char *returnSurfName, int returnSize );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static void CG_General( centity_t *cent ) {
 	refEntity_t			ent;

--- a/source/cgame/cg_event.c
+++ b/source/cgame/cg_event.c
@@ -1188,9 +1188,9 @@ void CG_GetCTFMessageEvent(entityState_t *es)
 	CG_PrintCTFMessage(ci, teamName, es->eventParm);
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_InKnockDownOnly( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void DoFall(centity_t *cent, entityState_t *es, int clientNum)
 {

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -1949,10 +1949,10 @@ extern	vmCvar_t		cg_smoothClients;
 extern	vmCvar_t		ojp_sabermelee;
 //[/MELEE]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern	vmCvar_t		pmove_fixed;
 extern	vmCvar_t		pmove_msec;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //extern	vmCvar_t		cg_pmove_fixed;
 extern	vmCvar_t		cg_cameraOrbit;
@@ -2357,7 +2357,7 @@ void CG_AdjustEyePos (const char *modelName);
 // These functions are how the cgame communicates with the main game system
 //
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 // print message on the local console
 void		trap_Print( const char *fmt );
@@ -2584,7 +2584,7 @@ void		BG_CycleInven(playerState_t *ps, int direction);
 int			BG_ProperForceIndex(int power);
 void		BG_CycleForce(playerState_t *ps, int direction);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 typedef enum {
@@ -2593,7 +2593,7 @@ typedef enum {
   TEAMCHAT_PRINT
 } q3print_t; // bk001201 - warning: useless keyword or type name in empty declaration
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 int trap_CIN_PlayCinematic( const char *arg0, int xpos, int ypos, int width, int height, int bits);
 e_status trap_CIN_StopCinematic(int handle);
@@ -2654,7 +2654,7 @@ qboolean	trap_ROFF_Purge_Ent( int entID );
 void	trap_TrueMalloc(void **ptr, int size);
 void	trap_TrueFree(void **ptr);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void	CG_ClearParticles (void);
 void	CG_AddParticles (void);
@@ -2720,7 +2720,7 @@ void FX_BlasterAltFireThink( centity_t *cent, const struct weaponInfo_s *weapon 
 void FX_BlasterWeaponHitWall( vec3_t origin, vec3_t normal );
 void FX_BlasterWeaponHitPlayer( vec3_t origin, vec3_t normal, qboolean humanoid );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 void		trap_G2API_CollisionDetect		( CollisionRecord_t *collRecMap, void* ghoul2, const vec3_t angles, const vec3_t position,int frameNumber, int entNum, const vec3_t rayStart, const vec3_t rayEnd, const vec3_t scale, int traceFlags, int useLod, float fRadius );
 void		trap_G2API_CollisionDetectCache		( CollisionRecord_t *collRecMap, void* ghoul2, const vec3_t angles, const vec3_t position,int frameNumber, int entNum, const vec3_t rayStart, const vec3_t rayEnd, const vec3_t scale, int traceFlags, int useLod, float fRadius );
@@ -2808,7 +2808,7 @@ qboolean	trap_G2API_OverrideServer(void *serverInstance);
 
 void		trap_G2API_GetSurfaceName(void *ghoul2, int surfNumber, int modelIndex, char *fillBuf);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void		CG_Init_CG(void);
 void		CG_Init_CGents(void);

--- a/source/cgame/cg_main.c
+++ b/source/cgame/cg_main.c
@@ -122,9 +122,9 @@ void CG_Shutdown( void );
 void CG_CalcEntityLerpPositions( centity_t *cent );
 void CG_ROFF_NotetrackCallback( centity_t *cent, const char *notetrack);
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void UI_CleanupGhoul2(void);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static int	C_PointContents(void);
 static void C_GetLerpOrigin(void);
@@ -184,7 +184,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11  ) {
 
 	switch ( command ) {
@@ -357,7 +357,7 @@ int vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int a
 	}
 	return -1;
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static int C_PointContents(void)
 {
@@ -856,13 +856,13 @@ vmCvar_t 	cg_smoothClients;
 vmCvar_t	ojp_sabermelee;
 //[/MELEE]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 vmCvar_t	pmove_fixed;
 //vmCvar_t	cg_pmove_fixed;
 vmCvar_t	pmove_msec;
 // nmckenzie: DUEL_HEALTH
 vmCvar_t	g_showDuelHealths;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 vmCvar_t	cg_pmove_msec;
 vmCvar_t	cg_cameraMode;
@@ -1438,12 +1438,12 @@ const char *CG_Argv( int arg ) {
 //========================================================================
 
 //so shared code can get the local time depending on the side it's executed on
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_GetTime(void)
 {
 	return cg.time;
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 =================
@@ -3884,9 +3884,9 @@ CG_SpawnCGameEntFromVars
 See if we should do something for this ent cgame-side -rww
 ==============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void BG_ParseField( BG_field_t *l_fields, const char *key, const char *value, byte *ent );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern float cg_linearFogOverride; //cg_view.c
 extern float cg_radarRange;//cg_draw.c
@@ -3973,10 +3973,10 @@ Ghoul2 Insert End
 extern playerState_t *cgSendPS[MAX_GENTITIES]; //is not MAX_CLIENTS because NPCs exceed MAX_CLIENTS
 void CG_PmoveClientPointerUpdate();
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void WP_SaberLoadParms( void );
 void BG_VehicleLoadParms( void );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[WEAPONSDAT]
 extern void BG_LoadWeaponsData();

--- a/source/cgame/cg_newDraw.c
+++ b/source/cgame/cg_newDraw.c
@@ -264,9 +264,9 @@ const char *CG_GameTypeString(void) {
 	return "";
 }
 						 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int MenuFontToHandle(int iMenuFont);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 // maxX param is initially an X limit, but is also used as feedback. 0 = text was clipped to fit within, else maxX = next pos
 //

--- a/source/cgame/cg_players.c
+++ b/source/cgame/cg_players.c
@@ -1339,10 +1339,10 @@ qboolean	trueviewwarning = qfalse;
 CG_RegisterClientModelname
 ==========================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_IsValidCharacterModel(const char *modelName, const char *skinName);
 qboolean BG_ValidateSkinForTeam( const char *modelName, char *skinName, int team, float *colors );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static qboolean CG_RegisterClientModelname( clientInfo_t *ci, const char *modelName, const char *skinName, const char *teamName, int clientNum ) {
 	int handle;
@@ -2565,9 +2565,9 @@ void ParseRGBSaber(char * str, vec3_t c);
 void CG_ParseScriptedSaber(char *script, clientInfo_t *ci, int snum);
 //[/RGBSabers]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void WP_SetSaber( int entNum, saberInfo_t *sabers, int saberNum, const char *saberName );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 extern void *CG_G2WeaponInstance2(centity_t *cent, int weapon);
 
 void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
@@ -4008,10 +4008,10 @@ qboolean CG_InRollAnim( centity_t *cent )
 CG_SetLerpFrameAnimation
 ===============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SaberStanceAnim( int anim );
 qboolean PM_RunningAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 static void CG_SetLerpFrameAnimation( centity_t *cent, clientInfo_t *ci, lerpFrame_t *lf, int newAnimation, float animSpeedMult, qboolean torsoOnly, qboolean flipState) {
 	animation_t	*anim;
 	float animSpeed;
@@ -4512,9 +4512,9 @@ static void CG_ClearLerpFrame( centity_t *cent, clientInfo_t *ci, lerpFrame_t *l
 CG_PlayerAnimation
 ===============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean PM_WalkingAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static void CG_PlayerAnimation( centity_t *cent, int *legsOld, int *legs, float *legsBackLerp,
 						int *torsoOld, int *torso, float *torsoBackLerp ) {
@@ -10655,9 +10655,9 @@ void CG_SaberCompWork(vec3_t start, vec3_t end, centity_t *owner, int saberNum, 
 #define SABER_TRAIL_TIME	40.0f
 #define FX_USE_ALPHA		0x08000000
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SuperBreakWinAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void CG_AddSaberBlade( centity_t *cent, centity_t *scent, refEntity_t *saber, int renderfx, int modelIndex, int saberNum, int bladeNum, vec3_t origin, vec3_t angles, qboolean fromSaber, qboolean dontDraw)
 {
@@ -11908,10 +11908,10 @@ int CG_HandleAppendedSkin(char *modelName)
 }
 
 //Create a temporary ghoul2 instance and get the gla name so we can try loading animation data and sounds.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void BG_GetVehicleModelName(char *modelname);
 void BG_GetVehicleSkinName(char *skinname);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void CG_CacheG2AnimInfo(char *modelName)
 {
@@ -12032,12 +12032,12 @@ static void CG_RegisterVehicleAssets( Vehicle_t *pVeh )
 
 extern void CG_HandleNPCSounds(centity_t *cent);
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void G_CreateAnimalNPC( Vehicle_t **pVeh, const char *strAnimalType );
 extern void G_CreateSpeederNPC( Vehicle_t **pVeh, const char *strType );
 extern void G_CreateWalkerNPC( Vehicle_t **pVeh, const char *strAnimalType );
 extern void G_CreateFighterNPC( Vehicle_t **pVeh, const char *strType );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern playerState_t *cgSendPS[MAX_GENTITIES];
 void CG_G2AnimEntModelLoad(centity_t *cent)
@@ -13467,9 +13467,9 @@ static CGAME_INLINE void CG_VehicleEffects(centity_t *cent)
 CG_Player
 ===============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_EmplacedView(vec3_t baseAngles, vec3_t angles, float *newYaw, float constraint);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 float CG_RadiusForCent( centity_t *cent )
 {

--- a/source/cgame/cg_predict.c
+++ b/source/cgame/cg_predict.c
@@ -208,11 +208,11 @@ CG_ClipMoveToEntities
 
 ====================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void BG_VehicleAdjustBBoxForOrientation( Vehicle_t *veh, vec3_t origin, vec3_t mins, vec3_t maxs,
 										int clientNum, int tracemask,
 										void (*localTrace)(trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask)); // bg_pmove.c
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 static void CG_ClipMoveToEntities ( const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end,
 							int skipNumber, int mask, trace_t *tr, qboolean g2Check ) {
 	int			i, x, zd, zu;

--- a/source/cgame/cg_strap.c
+++ b/source/cgame/cg_strap.c
@@ -1,7 +1,7 @@
 //rww - shared trap call system
 #include "cg_local.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 qboolean strap_G2API_GetBoltMatrix(void *ghoul2, const int modelIndex, const int boltIndex, mdxaBone_t *matrix,
 								const vec3_t angles, const vec3_t position, const int frameNum, qhandle_t *modelList, vec3_t scale)
@@ -70,4 +70,4 @@ void strap_TrueFree(void **ptr)
 	trap_TrueFree(ptr);
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/cgame/cg_syscalls.c
+++ b/source/cgame/cg_syscalls.c
@@ -6,7 +6,7 @@
 
 static int (QDECL *syscall)( int arg, ... ) = (int (QDECL *)( int, ...))-1;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void dllEntry( int (QDECL  *syscallptr)( int arg,... ) ) {
 	syscall = syscallptr;
 }
@@ -1121,4 +1121,4 @@ void trap_WE_AddWeatherZone( const vec3_t mins, const vec3_t maxs )
 Ghoul2 Insert End
 */
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/cgame/cg_view.c
+++ b/source/cgame/cg_view.c
@@ -2262,9 +2262,9 @@ CG_EmplacedView
 Keep view reasonably constrained in relation to gun -rww
 =================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_EmplacedView(vec3_t baseAngles, vec3_t angles, float *newYaw, float constraint);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void CG_EmplacedView(vec3_t angles)
 {
@@ -2518,10 +2518,10 @@ Generates and draws a game scene and status information at the given time.
 static qboolean cg_rangedFogging = qfalse; //so we know if we should go back to normal fog
 float cg_linearFogOverride = 0.0f; //designer-specified override for linear fogging style
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void BG_VehicleTurnRateForSpeed( Vehicle_t *pVeh, float speed, float *mPitchOverride, float *mYawOverride );
 extern qboolean PM_InKnockDown( playerState_t *ps );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern qboolean cgQueueLoad;
 extern void CG_ActualLoadDeferredPlayers( void );

--- a/source/game/AnimalNPC.c
+++ b/source/game/AnimalNPC.c
@@ -77,12 +77,12 @@ extern vec3_t playerMaxs;
 extern cvar_t	*g_speederControlScheme;
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 extern void PM_SetAnim(pmove_t	*pm,int setAnimParts,int anim,int setAnimFlags, int blendTime);
 extern int PM_AnimLength( int index, animNumber_t anim );
 #ifdef _JK2MP
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 #ifndef	_JK2MP
@@ -155,7 +155,7 @@ static bool Update( Vehicle_t *pVeh, const usercmd_t *pUcmd )
 #endif //QAGAME
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 //MP RULE - ALL PROCESSMOVECOMMANDS FUNCTIONS MUST BE BG-COMPATIBLE!!!
@@ -888,7 +888,7 @@ void G_SetAnimalVehicleFunctions( vehicleInfo_t *pVehInfo )
 
 // Following is only in game, not in namespace
 #ifdef _JK2MP
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 #ifdef QAGAME
@@ -896,7 +896,7 @@ extern void G_AllocateVehicleObject(Vehicle_t **pVeh);
 #endif
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 // Create/Allocate a new Animal Vehicle (initializing it as well).
@@ -926,7 +926,7 @@ void G_CreateAnimalNPC( Vehicle_t **pVeh, const char *strAnimalType )
 
 #ifdef _JK2MP
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //get rid of all the crazy defs we added for this file
 #undef currentAngles

--- a/source/game/FighterNPC.c
+++ b/source/game/FighterNPC.c
@@ -84,7 +84,7 @@ extern qboolean BG_UnrestrainedPitchRoll( playerState_t *ps, Vehicle_t *pVeh );
 
 #ifdef _JK2MP
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern void BG_SetAnim(playerState_t *ps, animation_t *animations, int setAnimParts,int anim,int setAnimFlags, int blendTime);
 extern int BG_GetTime(void);
@@ -2022,7 +2022,7 @@ void G_SetFighterVehicleFunctions( vehicleInfo_t *pVehInfo )
 
 // Following is only in game, not in namespace
 #ifdef _JK2MP
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 #ifdef QAGAME
@@ -2030,7 +2030,7 @@ extern void G_AllocateVehicleObject(Vehicle_t **pVeh);
 #endif
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 // Create/Allocate a new Animal Vehicle (initializing it as well).
@@ -2058,7 +2058,7 @@ void G_CreateFighterNPC( Vehicle_t **pVeh, const char *strType )
 
 #ifdef _JK2MP
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //get rid of all the crazy defs we added for this file
 #undef currentAngles

--- a/source/game/JK2_game.vcxproj
+++ b/source/game/JK2_game.vcxproj
@@ -204,7 +204,9 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <AdditionalOptions>/W4 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_Debug;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/source/game/NPC_AI_GalakMech.c
+++ b/source/game/NPC_AI_GalakMech.c
@@ -10,9 +10,9 @@ extern qboolean WP_LobFire( gentity_t *self, vec3_t start, vec3_t target, vec3_t
 				float minSpeed, float maxSpeed, float idealSpeed, qboolean mustHit );
 extern void G_SoundOnEnt (gentity_t *ent, soundChannel_t channel, const char *soundPath);
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_CrouchAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //extern void NPC_Mark1_Part_Explode(gentity_t *self,int bolt);
 

--- a/source/game/NPC_AI_Grenadier.c
+++ b/source/game/NPC_AI_Grenadier.c
@@ -3,9 +3,9 @@
 #include "anims.h"
 //#include "g_navigator.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_SabersOff( playerState_t *ps );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern void CG_DrawAlert( vec3_t origin, float rating );
 extern void G_AddVoiceEvent( gentity_t *self, int event, int speakDebounceTime );

--- a/source/game/NPC_AI_ImperialProbe.c
+++ b/source/game/NPC_AI_ImperialProbe.c
@@ -1,9 +1,9 @@
 #include "b_local.h"
 #include "g_nav.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 gitem_t	*BG_FindItemForAmmo( ammo_t ammo );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 extern void G_SoundOnEnt( gentity_t *ent, soundChannel_t channel, const char *soundPath );
 
 //Local state enums

--- a/source/game/NPC_AI_Jedi.c
+++ b/source/game/NPC_AI_Jedi.c
@@ -4,9 +4,9 @@
 #include "anims.h"
 #include "w_saber.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_SabersOff( playerState_t *ps );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern void CG_DrawAlert( vec3_t origin, float rating );
 extern void G_AddVoiceEvent( gentity_t *self, int event, int speakDebounceTime );
@@ -43,9 +43,9 @@ extern qboolean G_ExpandPointToBBox( vec3_t point, const vec3_t mins, const vec3
 extern qboolean NPC_CheckEnemyStealth( void );
 extern void G_SoundOnEnt( gentity_t *ent, soundChannel_t channel, const char *soundPath );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern gitem_t	*BG_FindItemForAmmo( ammo_t ammo );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern void ForceThrow( gentity_t *self, qboolean pull );
 extern void ForceLightning( gentity_t *self );
@@ -62,7 +62,7 @@ extern void WP_DeactivateSaber( gentity_t *self, qboolean clearLength ); //clear
 extern void WP_ActivateSaber( gentity_t *self );
 //extern void WP_SaberBlock(gentity_t *saber, vec3_t hitloc);
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean PM_SaberInStart( int move );
 extern qboolean BG_SaberInSpecialAttack( int anim );
 extern qboolean BG_SaberInAttack( int move );
@@ -77,7 +77,7 @@ extern qboolean PM_RollingAnim( int anim );
 extern qboolean PM_InKnockDown( playerState_t *ps );
 extern qboolean BG_InRoll( playerState_t *ps, int anim );
 extern qboolean BG_CrouchAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern qboolean NPC_SomeoneLookingAtMe(gentity_t *ent);
 
@@ -88,9 +88,9 @@ extern void G_TestLine(vec3_t start, vec3_t end, int color, int time);
 static void Jedi_Aggression( gentity_t *self, int change );
 qboolean Jedi_WaitingAmbush( gentity_t *self );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int bg_parryDebounce[];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static int	jediSpeechDebounceTime[TEAM_NUM_TEAMS];//used to stop several jedi from speaking all at once
 //Local state enums

--- a/source/game/NPC_AI_Mark1.c
+++ b/source/game/NPC_AI_Mark1.c
@@ -38,9 +38,9 @@ qboolean NPC_CheckPlayerTeamStealth( void );
 void Mark1_BlasterAttack(qboolean advance);
 void DeathFX( gentity_t *ent );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern gitem_t *BG_FindItemForAmmo( ammo_t ammo );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 -------------------------

--- a/source/game/NPC_AI_Mark2.c
+++ b/source/game/NPC_AI_Mark2.c
@@ -11,9 +11,9 @@
 #define MIN_DISTANCE		24
 #define MIN_DISTANCE_SQR	( MIN_DISTANCE * MIN_DISTANCE )
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern gitem_t	*BG_FindItemForAmmo( ammo_t ammo );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //Local state enums
 enum

--- a/source/game/NPC_AI_Sentry.c
+++ b/source/game/NPC_AI_Sentry.c
@@ -1,9 +1,9 @@
 #include "b_local.h"
 #include "g_nav.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern gitem_t	*BG_FindItemForAmmo( ammo_t ammo );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 extern void G_SoundOnEnt( gentity_t *ent, soundChannel_t channel, const char *soundPath );
 
 #define MIN_DISTANCE		256

--- a/source/game/NPC_behavior.c
+++ b/source/game/NPC_behavior.c
@@ -16,9 +16,9 @@ extern vec3_t NPCDEBUG_BLUE;
 extern void G_Cube( vec3_t mins, vec3_t maxs, vec3_t color, float alpha );
 extern void NPC_CheckGetNewWeapon( void );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean PM_InKnockDown( playerState_t *ps );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern void NPC_AimAdjust( int change );
 extern qboolean NPC_SomeoneLookingAtMe(gentity_t *ent);

--- a/source/game/NPC_move.c
+++ b/source/game/NPC_move.c
@@ -19,9 +19,9 @@ extern int GetTime ( int lastTime );
 navInfo_t	frameNavInfo;
 extern qboolean FlyingCreature( gentity_t *ent );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean PM_InKnockDown( playerState_t *ps );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[CoOp]
 static qboolean NPC_TryJump_Final();

--- a/source/game/NPC_reactions.c
+++ b/source/game/NPC_reactions.c
@@ -14,7 +14,7 @@ extern qboolean Jedi_WaitingAmbush( gentity_t *self );
 extern void Jedi_Ambush( gentity_t *self );
 extern qboolean NPC_SomeoneLookingAtMe(gentity_t *ent);
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_SaberInSpecialAttack( int anim );
 extern qboolean PM_SpinningSaberAnim( int anim );
 extern qboolean PM_SpinningAnim( int anim );
@@ -23,7 +23,7 @@ extern qboolean BG_FlippingAnim( int anim );
 extern qboolean PM_RollingAnim( int anim );
 extern qboolean PM_InCartwheel( int anim );
 extern qboolean BG_CrouchAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern int	teamLastEnemyTime[];
 extern int killPlayerTimer;

--- a/source/game/NPC_spawn.c
+++ b/source/game/NPC_spawn.c
@@ -1703,12 +1703,12 @@ void NPC_DefaultScriptFlags( gentity_t *ent )
 NPC_Spawn_Go
 -------------------------
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void G_CreateAnimalNPC( Vehicle_t **pVeh, const char *strAnimalType );
 extern void G_CreateSpeederNPC( Vehicle_t **pVeh, const char *strType );
 extern void G_CreateWalkerNPC( Vehicle_t **pVeh, const char *strAnimalType );
 extern void G_CreateFighterNPC( Vehicle_t **pVeh, const char *strType );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[CoOp]
 #define TURN_ON				0x00000000

--- a/source/game/NPC_stats.c
+++ b/source/game/NPC_stats.c
@@ -6,10 +6,10 @@
 
 extern qboolean NPCsPrecached;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean WP_SaberParseParms( const char *SaberName, saberInfo_t *saber );
 extern void WP_RemoveSaber( saberInfo_t *sabers, int saberNum );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 stringID_table_t TeamTable[] =
 {
@@ -144,10 +144,10 @@ stringID_table_t BSETTable[] =
 	{"",				-1},
 };
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern stringID_table_t WPTable[];
 extern stringID_table_t FPTable[];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 char	*TeamNames[TEAM_NUM_TEAMS] = 
 {
@@ -258,9 +258,9 @@ int NPC_ReactionTime ( void )
 // parse support routines
 //
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_ParseLiteral( const char **data, const char *string );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //
 // NPC parameters file : scripts/NPCs.cfg
@@ -361,9 +361,9 @@ static rank_t TranslateRankName( const char *name )
 	return RANK_CIVILIAN;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern saber_colors_t TranslateSaberColor( const char *name );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /* static int MethodNameToNumber( const char *name ) {
 	if ( !Q_stricmp( name, "EXPONENTIAL" ) ) {

--- a/source/game/SpeederNPC.c
+++ b/source/game/SpeederNPC.c
@@ -83,7 +83,7 @@ extern int PM_AnimLength( int index, animNumber_t anim );
 
 #ifdef _JK2MP
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern void BG_SetAnim(playerState_t *ps, animation_t *animations, int setAnimParts,int anim,int setAnimFlags, int blendTime);
 extern int BG_GetTime(void);
@@ -1077,7 +1077,7 @@ void G_SetSpeederVehicleFunctions( vehicleInfo_t *pVehInfo )
 
 // Following is only in game, not in namespace
 #ifdef _JK2MP
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 #ifdef QAGAME
@@ -1085,7 +1085,7 @@ extern void G_AllocateVehicleObject(Vehicle_t **pVeh);
 #endif
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 // Create/Allocate a new Animal Vehicle (initializing it as well).
@@ -1114,7 +1114,7 @@ void G_CreateSpeederNPC( Vehicle_t **pVeh, const char *strType )
 
 #ifdef _JK2MP
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //get rid of all the crazy defs we added for this file
 #undef currentAngles

--- a/source/game/WalkerNPC.c
+++ b/source/game/WalkerNPC.c
@@ -116,7 +116,7 @@ static bool Board( Vehicle_t *pVeh, bgEntity_t *pEnt )
 #endif //QAGAME
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 //MP RULE - ALL PROCESSMOVECOMMANDS FUNCTIONS MUST BE BG-COMPATIBLE!!!
@@ -804,7 +804,7 @@ void G_SetWalkerVehicleFunctions( vehicleInfo_t *pVehInfo )
 
 // Following is only in game, not in namespace
 #ifdef _JK2MP
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 #ifdef QAGAME
@@ -812,7 +812,7 @@ extern void G_AllocateVehicleObject(Vehicle_t **pVeh);
 #endif
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 // Create/Allocate a new Animal Vehicle (initializing it as well).
@@ -842,7 +842,7 @@ void G_CreateWalkerNPC( Vehicle_t **pVeh, const char *strAnimalType )
 
 #ifdef _JK2MP
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //get rid of all the crazy defs we added for this file
 #undef currentAngles

--- a/source/game/ai_main.h
+++ b/source/game/ai_main.h
@@ -597,10 +597,10 @@ extern float gDeactivated;
 extern float gBotEdit;
 extern int gWPRenderedFrame;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern wpobject_t *gWPArray[MAX_WPARRAY_SIZE];
 extern int gWPNum;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern int gLastPrintedIndex;
 extern nodeobject_t nodetable[MAX_NODETABLE_SIZE];

--- a/source/game/ai_wpnav.c
+++ b/source/game/ai_wpnav.c
@@ -8,10 +8,10 @@ float gDeactivated = 0;
 float gBotEdit = 0;
 int gWPRenderedFrame = 0;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 wpobject_t *gWPArray[MAX_WPARRAY_SIZE];
 int gWPNum = 0;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 int gLastPrintedIndex = -1;
 

--- a/source/game/bg_g2_utils.c
+++ b/source/game/bg_g2_utils.c
@@ -20,7 +20,7 @@
 #endif
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 void BG_AttachToRancor( void *ghoul2,
 					   float rancYaw,
@@ -179,4 +179,4 @@ qboolean BG_GetRootSurfNameWithVariant( void *ghoul2, const char *rootSurfName, 
 	return qfalse;
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_local.h
+++ b/source/game/bg_local.h
@@ -30,7 +30,7 @@ typedef struct
 	int			previous_waterlevel;
 } pml_t;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern	pml_t		pml;
 
@@ -58,10 +58,10 @@ int		trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 void	trap_FS_Read( void *buffer, int len, fileHandle_t f );
 void	trap_FS_Write( const void *buffer, int len, fileHandle_t f );
 void	trap_FS_FCloseFile( fileHandle_t f );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //PM anim utility functions:
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean PM_SaberInParry( int move );
 qboolean PM_SaberInKnockaway( int move );
 
@@ -111,7 +111,7 @@ void PM_SetForceJumpZStart(float value);
 
 void BG_CycleInven(playerState_t *ps, int direction);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[Melee]
 qboolean PM_DoKick(void); //pm function for performing kicks

--- a/source/game/bg_misc.c
+++ b/source/game/bg_misc.c
@@ -24,7 +24,7 @@
 extern void Q3_SetParm (int entID, int parmNum, const char *parmValue);
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 const char *bgToggleableSurfaces[BG_NUM_TOGGLEABLE_SURFACES] = 
 {
@@ -439,7 +439,7 @@ qboolean BG_FileExists(const char *fileName)
 
 // Following functions don't need to be in namespace, they're already
 // different per-module
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 #ifdef QAGAME
 char *G_NewString( const char *string );
@@ -447,7 +447,7 @@ char *G_NewString( const char *string );
 char *CG_NewString( const char *string );
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 /*
 ===============
@@ -3744,4 +3744,4 @@ qboolean BG_IsUsingHeavyWeap (playerState_t *ps)
 	};
 }
 //[/ForceSys]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_panimate.c
+++ b/source/game/bg_panimate.c
@@ -11,13 +11,13 @@
 #endif
 
 #ifdef CGAME
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern sfxHandle_t trap_S_RegisterSound( const char *sample);
 extern int trap_FX_RegisterEffect( const char *file);
 //[SaberSys]
 extern void trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize );
 //[/SaberSys]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 extern saberInfo_t *BG_MySaber( int clientNum, int saberNum );
@@ -31,7 +31,7 @@ BEGIN: Animation utility functions (sequence checking)
 // VVFIXME - Most of these functions are totally stateless and stupid. Don't
 // need multiple copies of this, but it's much easier (and less likely to
 // break in the future) if I keep separate namespace versions now.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 qboolean BG_SaberStanceAnim( int anim )
 {
@@ -3907,7 +3907,7 @@ float BG_GetLegsAnimPoint(playerState_t * ps, int AnimIndex)
 //[/BugFix2]
 //[/AnimationSys]
 
-#include "../namespace_end.h"		// End of animation utilities
+//#include "../namespace_end.h" //VOLGARENOK: deprecated		// End of animation utilities
 
 //[DodgeSys]
 qboolean BG_HopAnim( int anim )

--- a/source/game/bg_pmove.c
+++ b/source/game/bg_pmove.c
@@ -21,7 +21,7 @@ extern qboolean TryGrapple(gentity_t *ent); //g_cmds.c
 extern void trap_FX_PlayEffect( const char *file, vec3_t org, vec3_t fwd, int vol, int rad );
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_FullBodyTauntAnim( int anim );
 extern float PM_WalkableGroundDistance(void);
 extern qboolean PM_GroundSlideOkay( float zNormal );
@@ -840,7 +840,7 @@ void BG_VehicleTurnRateForSpeed( Vehicle_t *pVeh, float speed, float *mPitchOver
 	}
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 // Following couple things don't belong in the DLL namespace!
 #ifdef QAGAME
@@ -853,7 +853,7 @@ gentity_t *G_PlayEffectID(const int fxID, vec3_t org, vec3_t ang);
 #endif
 
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 static void PM_GroundTraceMissed( void );
 void PM_HoverTrace( void )
@@ -9833,7 +9833,7 @@ static void PM_DropTimers( void ) {
 // which includes files that are also compiled in SP. We do need to make
 // sure we only get one copy in the linker, though.
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern	vmCvar_t	bg_fighterAltControl;
 qboolean BG_UnrestrainedPitchRoll( playerState_t *ps, Vehicle_t *pVeh )
@@ -9851,7 +9851,7 @@ qboolean BG_UnrestrainedPitchRoll( playerState_t *ps, Vehicle_t *pVeh )
 	}
 	return qfalse;
 }
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 /*
 ================
@@ -14617,4 +14617,4 @@ qboolean PM_GettingUpFromKnockDown( float standheight, float crouchheight )
 }
 //[/KnockdownSys]
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_public.h
+++ b/source/game/bg_public.h
@@ -250,12 +250,12 @@ typedef enum {
 
 #define MAX_CUSTOM_SIEGE_SOUNDS 30
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern const char *bg_customSiegeSoundNames[MAX_CUSTOM_SIEGE_SOUNDS];
 
 extern const char *bgToggleableSurfaces[BG_NUM_TOGGLEABLE_SURFACES];
 extern const int bgToggleableSurfaceDebris[BG_NUM_TOGGLEABLE_SURFACES];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 typedef enum {
 	HANDEXTEND_NONE = 0,
@@ -320,9 +320,9 @@ typedef enum { GENDER_MALE, GENDER_FEMALE, GENDER_NEUTER } gender_t;
 extern vec3_t WP_MuzzlePoint[WP_NUM_WEAPONS];
 extern vec3_t WP_MuzzlePoint2[WP_NUM_WEAPONS];//[DualPistols]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int forcePowerSorted[NUM_FORCE_POWERS];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[Linux]
 #ifndef __linux__
@@ -377,10 +377,10 @@ typedef struct animation_s {
 } animation_t;
 #pragma pack(pop)
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean			BGPAFtextLoaded;
 extern animation_t		bgHumanoidAnimations[MAX_TOTALANIMATIONS];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[Asteroids]
 #define MAX_ANIM_FILES	64
@@ -482,7 +482,7 @@ typedef struct
 */
 //[/ANIMEVENTS]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern bgLoadedAnim_t bgAllAnims[MAX_ANIM_FILES];
 
@@ -500,7 +500,7 @@ extern bgLoadedAnim_t bgAllAnims[MAX_ANIM_FILES];
 //[/ANIMEVENTS]
 #endif
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 typedef enum {
 	PM_NORMAL,		// can accelerate and turn
@@ -543,7 +543,7 @@ enum {
 	NUM_FORCE_MASTERY_LEVELS
 };
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern char *forceMasteryLevels[NUM_FORCE_MASTERY_LEVELS];
 extern int forceMasteryPoints[NUM_FORCE_MASTERY_LEVELS];
 
@@ -563,7 +563,7 @@ extern int forceMasteryPoints[NUM_FORCE_MASTERY_LEVELS];
 extern int bgForcePowerCost[NUM_TOTAL_SKILLS][NUM_FORCE_POWER_LEVELS];
 //extern int bgForcePowerCost[NUM_FORCE_POWERS][NUM_FORCE_POWER_LEVELS];
 //[/ExpSys]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 // pmove->pm_flags
 #define	PMF_DUCKED			1
@@ -669,7 +669,7 @@ typedef struct {
 	int			entSize; //size of the struct (gentity_t or centity_t) so things can be dynamic
 } pmove_t;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern	pmove_t		*pm;
 
@@ -696,7 +696,7 @@ extern	pmove_t		*pm;
 void PM_UpdateViewAngles( playerState_t *ps, const usercmd_t *cmd );
 void Pmove (pmove_t *pmove);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //===================================================================================
 
@@ -1386,7 +1386,7 @@ typedef struct gitem_s {
 } gitem_t;
 
 // included in both the game dll and the client
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern	gitem_t	bg_itemlist[];
 extern	int		bg_numItems;
@@ -1401,7 +1401,7 @@ gitem_t	*BG_FindItemForHoldable( holdable_t pw );
 
 qboolean	BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const playerState_t *ps );
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 #define SABER_BLOCK_DUR 150		// number of milliseconds a block animation should take.
@@ -1761,7 +1761,7 @@ typedef struct
 	qboolean trailLength;
 } saberMoveData_t;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern saberMoveData_t	saberMoveData[LS_MOVE_MAX];
 
@@ -1769,7 +1769,7 @@ bgEntity_t *PM_BGEntForNum( int num );
 qboolean BG_KnockDownable(playerState_t *ps);
 qboolean BG_LegalizedForcePowers(char *powerOut, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 #ifdef __LCC__ //can't inline it then, it is declared over in bg_misc in this case
 void BG_GiveMeVectorFromMatrix(mdxaBone_t *boltMatrix, int flags, vec3_t vec);
@@ -1818,7 +1818,7 @@ static ID_INLINE void BG_GiveMeVectorFromMatrix(mdxaBone_t *boltMatrix, int flag
 }
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 void BG_IK_MoveArm(void *ghoul2, int lHandBolt, int time, entityState_t *ent, int basePose, vec3_t desiredPos, qboolean *ikInProgress,
 					 vec3_t origin, vec3_t angles, vec3_t scale, int blendTime, qboolean forceHalt);
@@ -1966,7 +1966,7 @@ extern int WeaponAttackAnim2[WP_NUM_WEAPONS];
 
 extern int forcePowerDarkLight[NUM_FORCE_POWERS];
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[KnockdownSys]
 //this is the default minimum time for a level 0 player to wait before they can attempt to get up.

--- a/source/game/bg_saber.c
+++ b/source/game/bg_saber.c
@@ -12,7 +12,7 @@ extern stringID_table_t SaberMoveTable[];
 #endif
 //[/SaberLockSys]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_SabersOff( playerState_t *ps );
 saberInfo_t *BG_MySaber( int clientNum, int saberNum );
 
@@ -1024,7 +1024,7 @@ int PM_SaberLockWinAnim( qboolean victory, qboolean superBreak )
 }
 
 // Need to avoid nesting namespaces!
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[SaberSys]
 extern void PM_DoPunch(void);
@@ -1050,7 +1050,7 @@ extern gentity_t g_entities[];
 //[/Mac]
 
 #endif
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 int PM_SaberLockLoseAnim( playerState_t *genemy, qboolean victory, qboolean superBreak )
 { 
@@ -5645,7 +5645,7 @@ saberInfo_t *BG_MySaber( int clientNum, int saberNum )
 	return NULL;
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 //[MELEE]

--- a/source/game/bg_saberLoad.c
+++ b/source/game/bg_saberLoad.c
@@ -7,27 +7,27 @@
 extern stringID_table_t animTable [MAX_ANIMATIONS+1];
 
 //Could use strap stuff but I don't particularly care at the moment anyway.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int	trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 extern void	trap_FS_Read( void *buffer, int len, fileHandle_t f );
 extern void	trap_FS_Write( const void *buffer, int len, fileHandle_t f );
 extern void	trap_FS_FCloseFile( fileHandle_t f );
 extern int	trap_FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize );
 extern qhandle_t trap_R_RegisterSkin( const char *name );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 #ifdef QAGAME
 extern int G_SoundIndex( const char *name );
 #elif defined CGAME
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 sfxHandle_t trap_S_RegisterSound( const char *sample);
 qhandle_t	trap_R_RegisterShader( const char *name );			// returns all white if not found
 int	trap_FX_RegisterEffect(const char *file);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 int BG_SoundIndex(char *sound)
 {
@@ -3154,4 +3154,4 @@ void BG_SI_DeactivateTrail ( saberInfo_t *saber, float duration )
 	}
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_saga.c
+++ b/source/game/bg_saga.c
@@ -13,7 +13,7 @@
 #define SIEGECHAR_TAB 9 //perhaps a bit hacky, but I don't think there's any define existing for "tab"
 
 //Could use strap stuff but I don't particularly care at the moment anyway.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern int	trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 extern void	trap_FS_Read( void *buffer, int len, fileHandle_t f );
@@ -1558,4 +1558,4 @@ int BG_SiegeFindClassIndexByName(const char *classname)
 //End misc/utility functions
 //======================================
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_saga.h
+++ b/source/game/bg_saga.h
@@ -84,7 +84,7 @@ typedef struct
 	int			friendlyShader;
 } siegeTeam_t;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern siegeClass_t bgSiegeClasses[MAX_SIEGE_CLASSES];
 extern int bgNumSiegeClasses;
@@ -110,4 +110,4 @@ int BG_SiegeFindClassIndexByName(const char *classname);
 extern char	siege_info[MAX_SIEGE_INFO_SIZE];
 extern int	siege_valid;
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_slidemove.c
+++ b/source/game/bg_slidemove.c
@@ -28,7 +28,7 @@ extern qboolean G_CanBeEnemy(gentity_t *self, gentity_t *enemy); //w_saber.c
 
 extern qboolean BG_UnrestrainedPitchRoll( playerState_t *ps, Vehicle_t *pVeh );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 extern bgEntity_t *pm_entSelf;
 extern bgEntity_t *pm_entVeh;
@@ -1118,5 +1118,5 @@ void PM_StepSlideMove( qboolean gravity ) {
 	}
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 

--- a/source/game/bg_strap.h
+++ b/source/game/bg_strap.h
@@ -2,7 +2,7 @@
 #include "q_shared.h"
 #include "bg_public.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 qboolean strap_G2API_GetBoltMatrix(void *ghoul2, const int modelIndex, const int boltIndex, mdxaBone_t *matrix,
 								const vec3_t angles, const vec3_t position, const int frameNum, qhandle_t *modelList, vec3_t scale);
@@ -35,4 +35,4 @@ void strap_TrueMalloc(void **ptr, int size);
 
 void strap_TrueFree(void **ptr);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/bg_vehicleLoad.c
+++ b/source/game/bg_vehicleLoad.c
@@ -13,13 +13,13 @@
 	#include "bg_weapons.h"
 
 	//Could use strap stuff but I don't particularly care at the moment anyway.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 	extern int	trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 	extern void	trap_FS_Read( void *buffer, int len, fileHandle_t f );
 	extern void	trap_FS_Write( const void *buffer, int len, fileHandle_t f );
 	extern void	trap_FS_FCloseFile( fileHandle_t f );
 	extern int	trap_FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #else
 	#include "g_local.h"
 	#define QAGAME
@@ -47,7 +47,7 @@ extern int G_SoundIndex( const char *name );
 		extern int G_EffectIndex( const char *name );
 	#endif
 #elif CGAME
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qhandle_t	trap_R_RegisterModel( const char *name );			// returns rgb axis if not found
 extern qhandle_t	trap_R_RegisterSkin( const char *name );			// returns all white if not found
 extern qhandle_t	trap_R_RegisterShader( const char *name );
@@ -56,15 +56,15 @@ extern int			trap_FX_RegisterEffect(const char *file);
 extern sfxHandle_t	trap_S_RegisterSound( const char *sample);		// returns buzz if not found
 
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #else//UI
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qhandle_t	trap_R_RegisterModel( const char *name );			// returns rgb axis if not found
 extern qhandle_t	trap_R_RegisterSkin( const char *name );			// returns all white if not found
 extern qhandle_t	trap_R_RegisterShader( const char *name );			// returns all white if not found
 extern qhandle_t	trap_R_RegisterShaderNoMip( const char *name );			// returns all white if not found
 extern sfxHandle_t	trap_S_RegisterSound( const char *sample);		// returns buzz if not found
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 extern stringID_table_t animTable [MAX_ANIMATIONS+1];
@@ -133,7 +133,7 @@ void BG_ClearVehicleParseParms(void)
 }
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 #ifndef WE_ARE_IN_THE_UI
@@ -1841,7 +1841,7 @@ void AttachRidersGeneric( Vehicle_t *pVeh )
 #endif
 //[/DynamicMemory_Vehicles]
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 #endif // _JK2MP
 

--- a/source/game/bg_vehicles.h
+++ b/source/game/bg_vehicles.h
@@ -45,9 +45,9 @@ typedef enum
 //ROP VEHICLE_IMP END
 
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern stringID_table_t VehicleTable[VH_NUM_VEHICLES+1];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //===========================================================================================================
 //START VEHICLE WEAPONS
@@ -95,10 +95,10 @@ typedef struct
 #define VEH_WEAPON_BASE	0
 #define VEH_WEAPON_NONE	-1
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern vehWeaponInfo_t g_vehWeaponInfo[MAX_VEH_WEAPONS];
 extern int	numVehicleWeapons;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //===========================================================================================================
 //END VEHICLE WEAPONS
@@ -414,10 +414,10 @@ typedef struct
 #define VEHICLE_BASE	0
 #define VEHICLE_NONE	-1
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern vehicleInfo_t g_vehicleInfo[MAX_VEHICLES];
 extern int	numVehicles;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 #define VEH_DEFAULT_SPEED_MAX		800.0f
 #define VEH_DEFAULT_ACCEL			10.0f
@@ -705,8 +705,8 @@ struct Vehicle_s
 #endif
 //[/Linux]//[/Mac]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int BG_VehicleGetIndex( const char *vehicleName );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 #endif	// __BG_VEHICLES_H

--- a/source/game/g_ICARUScb.c
+++ b/source/game/g_ICARUScb.c
@@ -20,7 +20,7 @@
 #include "g_camera.h"
 //[/CoOp]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SabersOff( playerState_t *ps );
 extern stringID_table_t WPTable[];
 extern stringID_table_t BSTable[];
@@ -28,7 +28,7 @@ extern stringID_table_t BSTable[];
 //[SuperDindon]
 extern stringID_table_t TeamTable[];
 //[/CoOp]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[CoOp]
 qboolean skippingCutscene = qfalse;  //toggle for cutscene skipping

--- a/source/game/g_active.c
+++ b/source/game/g_active.c
@@ -8,14 +8,14 @@
 extern void Jedi_Cloak( gentity_t *self );
 extern void Jedi_Decloak( gentity_t *self );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean PM_SaberInTransition( int move );
 qboolean PM_SaberInStart( int move );
 qboolean PM_SaberInReturn( int move );
 //[StanceSelection]
 //qboolean WP_SaberStyleValidForSaber( saberInfo_t *saber1, saberInfo_t *saber2, int saberHolstered, int saberAnimLevel );
 //[/StanceSelection]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 qboolean saberCheckKnockdown_DuelLoss(gentity_t *saberent, gentity_t *saberOwner, gentity_t *other);
 
 extern vmCvar_t g_saberLockRandomNess;
@@ -936,9 +936,9 @@ Events will be passed on to the clients for presentation,
 but any server game effects are handled here
 ================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_InKnockDownOnly( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 	int		i;//, j;

--- a/source/game/g_bot.c
+++ b/source/game/g_bot.c
@@ -32,14 +32,14 @@ extern gentity_t	*podium1;
 extern gentity_t	*podium2;
 extern gentity_t	*podium3;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 float trap_Cvar_VariableValue( const char *var_name ) {
 	char buf[128];
 
 	trap_Cvar_VariableStringBuffer(var_name, buf, sizeof(buf));
 	return atof(buf);
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 /*

--- a/source/game/g_client.c
+++ b/source/game/g_client.c
@@ -1658,11 +1658,11 @@ is used for determining where the lightsaber should be, and for per-poly collisi
 */
 void *g2SaberInstance = NULL;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_IsValidCharacterModel(const char *modelName, const char *skinName);
 qboolean BG_ValidateSkinForTeam( const char *modelName, char *skinName, int team, float *colors );
 void BG_GetVehicleModelName(char *modelname);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void SetupGameGhoul2Model(gentity_t *ent, char *modelname, char *skinName)
 {
@@ -2695,9 +2695,9 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 
 void G_WriteClientSessionData( gclient_t *client );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void WP_SetSaber( int entNum, saberInfo_t *sabers, int saberNum, const char *saberName );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 ===========
@@ -3049,10 +3049,10 @@ void G_BreakArm(gentity_t *ent, int arm)
 }
 
 //Update the ghoul2 instance anims based on the playerstate values
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SaberStanceAnim( int anim );
 qboolean PM_RunningAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 //[SaberLockSys]
 extern stringID_table_t animTable [MAX_ANIMATIONS+1];
 //[/SaberLockSys]

--- a/source/game/g_cmds.c
+++ b/source/game/g_cmds.c
@@ -21,9 +21,9 @@ extern	qboolean		in_camera;
 int AcceptBotCommand(char *cmd, gentity_t *pl);
 //end rww
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void WP_SetSaber(int entNum, saberInfo_t *sabers, int saberNum, const char *saberName);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void Cmd_NPC_f(gentity_t *ent);
 void SP_CreateSnow(gentity_t *ent);

--- a/source/game/g_combat.c
+++ b/source/game/g_combat.c
@@ -4053,9 +4053,9 @@ void LimbThink( gentity_t *ent )
 	ent->nextthink = level.time;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_GetRootSurfNameWithVariant( void *ghoul2, const char *rootSurfName, char *returnSurfName, int returnSize );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void G_Dismember( gentity_t *ent, gentity_t *enemy, vec3_t point, int limbType, float limbRollBase, float limbPitchBase, int deathAnim, qboolean postDeath )
 {

--- a/source/game/g_items.c
+++ b/source/game/g_items.c
@@ -1832,9 +1832,9 @@ void EWebPrecache(void)
 #define EWEB_DEATH_RADIUS		128
 #define EWEB_DEATH_DMG			90
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void BG_CycleInven(playerState_t *ps, int direction); //bg_misc.c
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void EWebDie(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod)
 {
@@ -2154,9 +2154,9 @@ void EWebUpdateBoneAngles(gentity_t *owner, gentity_t *eweb)
 }
 
 //keep it updated
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int BG_EmplacedView(vec3_t baseAngles, vec3_t angles, float *newYaw, float constraint); //bg_misc.c
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void EWebThink(gentity_t *self)
 {

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -1397,7 +1397,7 @@ Ghoul2 Insert Start
 */
 int G_BoneIndex( const char *name );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 qhandle_t	trap_R_RegisterSkin( const char *name );
 
@@ -1472,7 +1472,7 @@ void		trap_G2API_ClearAttachedInstance(int entityNum);
 void		trap_G2API_CleanEntAttachments(void);
 qboolean	trap_G2API_OverrideServer(void *serverInstance);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 Ghoul2 Insert End
@@ -2090,10 +2090,10 @@ extern	vmCvar_t	g_debugUp;
 //extern	vmCvar_t	g_blueteam;
 extern	vmCvar_t	g_smoothClients;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern	vmCvar_t	pmove_fixed;
 extern	vmCvar_t	pmove_msec;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern	vmCvar_t	g_enableBreath;
 extern	vmCvar_t	g_singlePlayer;
@@ -2369,7 +2369,7 @@ extern vmCvar_t		ojp_truebalance;//[TrueBalance]
 
 extern vmCvar_t ojp_modelscaleEnabled;//[Modelscale]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 void	trap_Printf( const char *fmt );
 void	trap_Error( const char *fmt );
@@ -2716,4 +2716,4 @@ void G_ShutdownGame( int restart );
 //[/CrashLog]
 
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/g_main.c
+++ b/source/game/g_main.c
@@ -228,10 +228,10 @@ vmCvar_t	g_debugRight;
 vmCvar_t	g_debugUp;
 vmCvar_t	g_smoothClients;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 vmCvar_t	pmove_fixed;
 vmCvar_t	pmove_msec;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 vmCvar_t	g_listEntity;
 //vmCvar_t	g_redteam;
@@ -1217,7 +1217,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 //[Linux]
 /*
 #ifdef __linux__
@@ -1421,7 +1421,7 @@ int vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int a
 #endif
 */
 //[/Linux]
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 
 void QDECL G_Printf( const char *fmt, ... ) {
@@ -1589,10 +1589,10 @@ void G_UpdateCvars( void ) {
 
 char gSharedBuffer[MAX_G_SHARED_BUFFER_SIZE];
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void WP_SaberLoadParms( void );
 void BG_VehicleLoadParms( void );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 ============
@@ -4686,12 +4686,12 @@ void NAV_CheckCalcPaths( void )
 }
 
 //so shared code can get the local time depending on the side it's executed on
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_GetTime(void)
 {
 	return level.time;
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 ================

--- a/source/game/g_misc.c
+++ b/source/game/g_misc.c
@@ -4134,9 +4134,9 @@ void misc_weapon_shooter_aim( gentity_t *self )
 }
 
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern stringID_table_t WPTable[];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void SP_misc_weapon_shooter( gentity_t *self )
 {

--- a/source/game/g_missile.c
+++ b/source/game/g_missile.c
@@ -9,9 +9,9 @@
 extern void laserTrapStick( gentity_t *ent, vec3_t endpos, vec3_t normal );
 extern void Jedi_Decloak( gentity_t *self );
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean FighterIsLanded( Vehicle_t *pVeh, playerState_t *parentPS );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 /*
 ================

--- a/source/game/g_spawn.c
+++ b/source/game/g_spawn.c
@@ -877,9 +877,9 @@ Spawn an entity and fill in all of the level fields from
 level.spawnVars[], then call the class specfic spawn function
 ===================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void BG_ParseField( BG_field_t *l_fields, const char *key, const char *value, byte *ent );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 void G_SpawnGEntityFromSpawnVars( qboolean inSubBSP ) {
 	int			i;
 	gentity_t	*ent;

--- a/source/game/g_strap.c
+++ b/source/game/g_strap.c
@@ -1,7 +1,7 @@
 //rww - shared trap call system
 #include "g_local.h"
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 qboolean strap_G2API_GetBoltMatrix(void *ghoul2, const int modelIndex, const int boltIndex, mdxaBone_t *matrix,
 								const vec3_t angles, const vec3_t position, const int frameNum, qhandle_t *modelList, vec3_t scale)
@@ -70,4 +70,4 @@ void strap_TrueFree(void **ptr)
 	trap_TrueFree(ptr);
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/g_syscalls.c
+++ b/source/game/g_syscalls.c
@@ -7,7 +7,7 @@
 
 static int (QDECL *syscall)( int arg, ... ) = (int (QDECL *)( int, ...))-1;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 //[Linux]
 /*
 #ifdef __linux__
@@ -1501,4 +1501,4 @@ void trap_Bot_CalculatePaths(int rmg)
 	syscall(G_BOT_CALCULATEPATHS, rmg);
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/game/g_utils.c
+++ b/source/game/g_utils.c
@@ -476,9 +476,9 @@ Finally reworked PM_SetAnim to allow non-pmove calls, so we take our
 local anim index into account and make the call -rww
 =============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void BG_SetAnim(playerState_t *ps, animation_t *animations, int setAnimParts,int anim,int setAnimFlags, int blendTime);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void G_SetAnim(gentity_t *ent, usercmd_t *ucmd, int setAnimParts, int anim, int setAnimFlags, int blendTime)
 {

--- a/source/game/g_vehicles.c
+++ b/source/game/g_vehicles.c
@@ -74,11 +74,11 @@ extern void G_Knockdown( gentity_t *self, gentity_t *attacker, const vec3_t push
 #endif
 
 #ifdef _JK2MP
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void BG_SetAnim(playerState_t *ps, animation_t *animations, int setAnimParts,int anim,int setAnimFlags, int blendTime);
 extern void BG_SetLegsAnimTimer(playerState_t *ps, int time );
 extern void BG_SetTorsoAnimTimer(playerState_t *ps, int time );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 void G_VehUpdateShields( gentity_t *targ );
 #ifdef QAGAME
 extern void VEH_TurretThink( Vehicle_t *pVeh, gentity_t *parent, int turretNum );
@@ -2645,9 +2645,9 @@ static bool UpdateRider( Vehicle_t *pVeh, bgEntity_t *pRider, usercmd_t *pUmcd )
 
 #ifdef _JK2MP //we want access to this one clientside, but it's the only
 //generic vehicle function we care about over there
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void AttachRidersGeneric( Vehicle_t *pVeh );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #endif
 
 // Attachs all the riders of this vehicle to their appropriate tag (*driver, *pass1, *pass2, whatever...).

--- a/source/game/g_weapon.c
+++ b/source/game/g_weapon.c
@@ -4835,9 +4835,9 @@ int SkillLevelforWeapon(gentity_t *ent, int weapon)
 FireWeapon
 ===============
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_EmplacedView(vec3_t baseAngles, vec3_t angles, float *newYaw, float constraint);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[WeapAccuracy]
 extern void G_AddMercBalance(gentity_t *self, int amount);

--- a/source/game/q_shared.h
+++ b/source/game/q_shared.h
@@ -357,13 +357,11 @@ static float LittleFloat (const float *l) { return FloatSwap(l); }
 
 typedef unsigned char 		byte;
 typedef unsigned short		word;
-//[Linux]
-#ifndef __linux__
-typedef unsigned long		ulong;
-#endif
-//[/Linux]
+typedef unsigned long		ulong;//deleted [Linux]
 
-typedef enum {qfalse, qtrue}	qboolean;
+typedef unsigned int qboolean; //VOLGARENOK: enum -> unsigned int.
+#define qtrue 1 //^^
+#define qfalse 0 //^^
 
 typedef int		qhandle_t;
 typedef int		thandle_t; //rwwRMG - inserted
@@ -412,7 +410,8 @@ typedef int		clipHandle_t;
 #define	MAX_SAY_TEXT	300
 
 // paramters for command buffer stuffing
-typedef enum {
+typedef enum cbufExec_e
+{
 	EXEC_NOW,			// don't return until completed, a VM should NEVER use this,
 						// because some commands might cause the VM to be unloaded...
 	EXEC_INSERT,		// insert at current position, but don't run yet
@@ -435,7 +434,8 @@ typedef enum {
 #endif
 
 //For system-wide prints
-enum WL_e {
+enum WL_e 
+{
 	WL_ERROR=1,
 	WL_WARNING,
 	WL_VERBOSE,
@@ -445,7 +445,8 @@ enum WL_e {
 extern float forceSpeedLevels[4];
 
 // print levels from renderer (FIXME: set up for game / cgame?)
-typedef enum {
+typedef enum printParm_e
+{
 	PRINT_ALL,
 	PRINT_DEVELOPER,		// only print when "developer 1"
 	PRINT_WARNING,
@@ -458,7 +459,8 @@ typedef enum {
 #endif
 
 // parameters to the main Error routine
-typedef enum {
+typedef enum errorParm_e
+{
 	ERR_FATAL,					// exit the entire game with a popup window
 	ERR_DROP,					// print to console and disconnect from game
 	ERR_SERVERDISCONNECT,		// don't kill server
@@ -511,7 +513,8 @@ typedef enum {
 	#define HUNK_DEBUG
 #endif
 
-typedef enum {
+typedef enum
+{
 	h_high,
 	h_low,
 	h_dontcare
@@ -559,13 +562,15 @@ typedef	int	fixed16_t;
 #endif
 
 
-typedef enum {
+typedef enum saberBlockType_e
+{
 	BLK_NO,
 	BLK_TIGHT,		// Block only attacks and shots around the saber itself, a bbox of around 12x12x12
 	BLK_WIDE		// Block all attacks in an area around the player in a rough arc of 180 degrees
 } saberBlockType_t;
 
-typedef enum {
+typedef enum saberBlockedType_e
+{
 	BLOCKED_NONE,
 	BLOCKED_BOUNCE_MOVE,	//[RACC] This is used for situations where you want to manually 
 							//set a animation (normally deflections.)  To use, set your 
@@ -588,13 +593,7 @@ typedef enum {
 } saberBlockedType_t;
 
 
-//[Linux]
-#ifndef __linux__
-typedef enum
-#else
-enum
-#endif
-//[/Linux]
+typedef enum saber_colors_e//deleted [Linux]
 {
 	SABER_RED,
 	SABER_ORANGE,
@@ -611,16 +610,9 @@ enum
 	//[/RGBSabers]
 	NUM_SABER_COLORS
 
-};
-typedef int saber_colors_t;
+} saber_colors_t;
 
-//[Linux]
-#ifndef __linux__
-typedef enum
-#else
-enum
-#endif
-//[/Linux]
+typedef enum forcePowers_e//deleted [Linux]
 {
 	FP_FIRST = 0,//marker
 	FP_HEAL = 0,//instant
@@ -642,11 +634,10 @@ enum
 	FP_SABER_DEFENSE,
 	FP_SABERTHROW,
 	NUM_FORCE_POWERS
-};
-typedef int forcePowers_t;
+} forcePowers_t;
 
 //[ExpSys]
-typedef enum
+typedef enum skills_e
 {
 	SK_JETPACK,		//jetpack skill
 	SK_PISTOL,		//blaster pistol
@@ -680,7 +671,7 @@ typedef enum
 #define NUM_TOTAL_SKILLS	(NUM_FORCE_POWERS+NUM_SKILLS)
 //[/ExpSys]
 
-typedef enum
+typedef enum saberType_e
 {
 	SABER_NONE = 0,
 	SABER_SINGLE,
@@ -737,7 +728,7 @@ typedef struct
 } bladeInfo_t;
 #define MAX_BLADES 8
 
-typedef enum
+typedef enum saber_styles_e
 {
 	SS_NONE = 0,
 	SS_FAST,
@@ -908,13 +899,7 @@ typedef struct
 } saberInfo_t;
 #define MAX_SABERS 2
 
-//[Linux]
-#ifndef __linux__
-typedef enum
-#else
-enum
-#endif
-//[/Linux]
+enum //deleted [Linux]
 {
 	FORCE_LEVEL_0,
 	FORCE_LEVEL_1,
@@ -1038,13 +1023,7 @@ enum sharedEIKMoveState
 };
 
 //material stuff needs to be shared
-//[Linux]
-#ifndef __linux__
-typedef enum //# material_e
-#else
-enum
-#endif
-//[/Linux]
+typedef enum material_e//deleted [Linux]
 {
 	MAT_METAL = 0,	// scorched blue-grey metal
 	MAT_GLASS,		// not a real chunk type, just plays an effect with glass sprites
@@ -1065,9 +1044,7 @@ enum
 	MAT_SNOWY_ROCK,	// gray & brown chunks
 
 	NUM_MATERIALS
-
-};
-typedef int material_t;
+} material_t;
 
 //rww - bot stuff that needs to be shared
 #define MAX_WPARRAY_SIZE 4096
@@ -1601,14 +1578,16 @@ void	QDECL Com_sprintf (char *dest, int size, const char *fmt, ...);
 
 
 // mode parm for FS_FOpenFile
-typedef enum {
+typedef enum fsMode_e
+{
 	FS_READ,
 	FS_WRITE,
 	FS_APPEND,
 	FS_APPEND_SYNC
 } fsMode_t;
 
-typedef enum {
+typedef enum fsOrigin_e
+{
 	FS_SEEK_CUR,
 	FS_SEEK_END,
 	FS_SEEK_SET
@@ -1735,7 +1714,8 @@ default values.
 #define	CVAR_PARENTAL		0x00001000		// lets cvar system know that parental stuff needs to be updated
 
 // nothing outside the Cvar_*() functions should modify these fields!
-typedef struct cvar_s {
+typedef struct cvar_s 
+{
 	char		*name;
 	char		*string;
 	char		*resetString;		// cvar_restart will reset to this value
@@ -1755,7 +1735,8 @@ typedef int	cvarHandle_t;
 
 // the modules that run in the virtual machine can't access the cvar_t directly,
 // so they must ask for structured updates
-typedef struct {
+typedef struct 
+{
 	cvarHandle_t	handle;
 	int			modificationCount;
 	float		value;
@@ -1791,7 +1772,8 @@ PlaneTypeForNormal
 
 // plane_t structure
 // !!! if this is changed, it must be changed in asm code too !!!
-typedef struct cplane_s {
+typedef struct cplane_s 
+{
 	vec3_t	normal;
 	float	dist;
 	byte	type;			// for fast side tests: 0,1,2 = axial, 3 = nonaxial
@@ -1815,7 +1797,7 @@ typedef struct
 	int			mLocation;
 	float		mBarycentricI; // two barycentic coodinates for the hit point
 	float		mBarycentricJ; // K = 1-I-J
-}CollisionRecord_t;
+} CollisionRecord_t;
 
 #define MAX_G2_COLLISIONS 16
 
@@ -1825,7 +1807,8 @@ typedef CollisionRecord_t G2Trace_t[MAX_G2_COLLISIONS];	// map that describes al
 Ghoul2 Insert End
 */
 // a trace is returned when a box is swept through the world
-typedef struct {
+typedef struct 
+{
 	byte		allsolid;	// if true, plane is not valid
 	byte		startsolid;	// if true, the initial point was in a solid area
 	short		entityNum;	// entity the contacted sirface is a part of
@@ -1850,14 +1833,16 @@ Ghoul2 Insert End
 
 
 // markfragments are returned by CM_MarkFragments()
-typedef struct {
+typedef struct 
+{
 	int		firstPoint;
 	int		numPoints;
 } markFragment_t;
 
 
 
-typedef struct {
+typedef struct 
+{
 	vec3_t		origin;
 	vec3_t		axis[3];
 } orientation_t;
@@ -1876,13 +1861,9 @@ typedef struct {
 // sound channels
 // channel 0 never willingly overrides
 // other channels will allways override a playing sound on that channel
-//[Linux]
-#ifndef __linux__
-typedef enum {
-#else
-enum {
-#endif
-//[/Linux]
+
+typedef enum soundChannel_e//deleted [Linux]
+{
 	CHAN_AUTO,	//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" # Auto-picks an empty channel to play sound on
 	CHAN_LOCAL,	//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" # menu sounds, etc
 	CHAN_WEAPON,//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" 
@@ -1897,8 +1878,7 @@ enum {
 	CHAN_MENU1,		//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" #menu stuff, etc
 	CHAN_VOICE_GLOBAL,  //## %s !!"W:\game\base\!!sound\voice\*.wav;*.mp3" # Causes mouth animation and is broadcast, like announcer
 	CHAN_MUSIC,	//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" #music played as a looping sound - added by BTO (VV)
-};
-typedef int soundChannel_t;
+} soundChannel_t;
 
 
 /*
@@ -1976,7 +1956,8 @@ Ghoul2 Insert End
 #define	RESERVED_CONFIGSTRINGS	2	// game can't modify below this, only the system can
 
 #define	MAX_GAMESTATE_CHARS	16000
-typedef struct {
+typedef struct
+{
 	int			stringOffsets[MAX_CONFIGSTRINGS];
 	char		stringData[MAX_GAMESTATE_CHARS];
 	int			dataCount;
@@ -1985,7 +1966,8 @@ typedef struct {
 //=========================================================
 
 // all the different tracking "channels"
-typedef enum {
+typedef enum trackchan_e
+{
 	TRACK_CHANNEL_NONE = 50,
 	TRACK_CHANNEL_1,
 	TRACK_CHANNEL_2,
@@ -1997,7 +1979,8 @@ typedef enum {
 
 #define TRACK_CHANNEL_MAX (NUM_TRACK_CHANNELS-50)
 
-typedef struct forcedata_s {
+typedef struct forcedata_s
+{
 	int			forcePowerDebounce[NUM_FORCE_POWERS];	//for effects that must have an interval
 	int			forcePowersKnown;
 	int			forcePowersActive;
@@ -2059,7 +2042,8 @@ typedef struct forcedata_s {
 } forcedata_t;
 
 
-typedef enum {
+typedef enum itemUseFail_e
+{
 	SENTRY_NOROOM = 1,
 	SENTRY_ALREADYPLACED,
 	SHIELD_NOROOM,
@@ -2102,7 +2086,8 @@ typedef enum {
 // playerState_t is a full superset of entityState_t as it is used by players,
 // so if a playerState_t is transmitted, the entityState_t can be fully derived
 // from it.
-typedef struct playerState_s {
+typedef struct playerState_s
+{
 	int			commandTime;	// cmd->serverTime of last executed command
 	int			pm_type;
 	int			bobCycle;		// for view bobbing and footstep generation
@@ -2553,7 +2538,7 @@ typedef struct siegePers_s
 
 
 
-typedef enum
+typedef enum genCmds_e
 {
 	GENCMD_SABERSWITCH = 1,
 	GENCMD_ENGAGE_DUEL,
@@ -2589,7 +2574,8 @@ typedef enum
 } genCmds_t;
 
 // usercmd_t is sent to the server each client frame
-typedef struct usercmd_s {
+typedef struct usercmd_s
+{
 	int				serverTime;
 	int				angles[3];
 	int 			buttons;
@@ -2604,7 +2590,8 @@ typedef struct usercmd_s {
 //===================================================================
 
 //rww - unsightly hack to allow us to make an FX call that takes a horrible amount of args
-typedef struct addpolyArgStruct_s {
+typedef struct addpolyArgStruct_s
+{
 	vec3_t				p[4];
 	vec2_t				ev[4];
 	int					numVerts;
@@ -2624,7 +2611,8 @@ typedef struct addpolyArgStruct_s {
 	int					flags;
 } addpolyArgStruct_t;
 
-typedef struct addbezierArgStruct_s {
+typedef struct addbezierArgStruct_s
+{
 	vec3_t start;
 	vec3_t end;
 	vec3_t control1;
@@ -2681,7 +2669,8 @@ typedef struct
 	float	curST[2];
 } effectTrailVertStruct_t;
 
-typedef struct effectTrailArgStruct_s {
+typedef struct effectTrailArgStruct_s
+{
 	effectTrailVertStruct_t		mVerts[4];
 	qhandle_t					mShader;
 	int							mSetFlags;
@@ -2710,7 +2699,8 @@ typedef struct
 // if entityState->solid == SOLID_BMODEL, modelindex is an inline model number
 #define	SOLID_BMODEL	0xffffff
 
-typedef enum {
+typedef enum
+{
 	TR_STATIONARY,
 	TR_INTERPOLATE,				// non-parametric, but interpolate between snapshots
 	TR_LINEAR,
@@ -2720,7 +2710,8 @@ typedef enum {
 	TR_GRAVITY
 } trType_t;
 
-typedef struct {
+typedef struct
+{
 	trType_t	trType;
 	int		trTime;
 	int		trDuration;			// if non 0, trTime + trDuration = stop time
@@ -2735,7 +2726,8 @@ typedef struct {
 // The messages are delta compressed, so it doesn't really matter if
 // the structure size is fairly large
 
-typedef struct entityState_s {
+typedef struct entityState_s
+{
 	int		number;			// entity index
 	int		eType;			// entityType_t
 	int		eFlags;
@@ -2900,7 +2892,8 @@ typedef struct entityState_s {
 	vec3_t		userVec2;
 } entityState_t;
 
-typedef enum {
+typedef enum connstate_e
+{
 	CA_UNINITIALIZED,
 	CA_DISCONNECTED, 	// not talking to a server
 	CA_AUTHORIZING,		// not used any more, was checking cd key 
@@ -2920,7 +2913,8 @@ typedef enum {
 //=============================================
 
 
-typedef struct qtime_s {
+typedef struct qtime_s 
+{
 	int tm_sec;     /* seconds after the minute - [0,59] */
 	int tm_min;     /* minutes after the hour - [0,59] */
 	int tm_hour;    /* hours since midnight - [0,23] */
@@ -2941,13 +2935,8 @@ typedef struct qtime_s {
 #define AS_MPLAYER			3 // (Obsolete)
 
 // cinematic states
-//[Linux]
-#ifndef __linux__
-typedef enum {
-#else
-enum {
-#endif
-//[/Linux]
+enum //deleted [Linux]
+{
 	FMV_IDLE,
 	FMV_PLAY,		// play
 	FMV_EOF,		// all other conditions, i.e. stop/EOF/abort
@@ -2956,22 +2945,17 @@ enum {
 	FMV_LOOPED,
 	FMV_ID_WAIT
 };
-typedef int e_status;
+typedef int e_status; //VOLGARENOK: need fix
 
-//[Linux]
-#ifndef __linux__
-typedef enum _flag_status {
-#else
-enum _flag_status {
-#endif
-//[/Linux]
+enum _flag_status//deleted [Linux]
+{
 	FLAG_ATBASE = 0,
 	FLAG_TAKEN,			// CTF
 	FLAG_TAKEN_RED,		// One Flag CTF
 	FLAG_TAKEN_BLUE,	// One Flag CTF
 	FLAG_DROPPED
 };
-typedef int flagStatus_t;
+typedef int flagStatus_t; //VOLGARENOK: need fix
 
 
 #define	MAX_GLOBAL_SERVERS			2048
@@ -3001,19 +2985,14 @@ float VectorDistance(vec3_t v1, vec3_t v2);
 Ghoul2 Insert Start
 */
 
-typedef struct {
+typedef struct
+{
 	float		matrix[3][4];
 } mdxaBone_t;
 
 // For ghoul2 axis use
 
-//[Linux]
-#ifndef __linux__
-typedef enum Eorientations
-#else
-enum Eorientations
-#endif
-//[/Linux]
+enum Eorientations//deleted [Linux]
 {
 	ORIGIN = 0, 
 	POSITIVE_X,
@@ -3031,13 +3010,9 @@ Ghoul2 Insert End
 // define the new memory tags for the zone, used by all modules now
 //
 #define TAGDEF(blah) TAG_ ## blah
-//[Linux]
-#ifndef __linux__
-typedef enum {
-#else
-enum {
-#endif
-//[/Linux]
+
+enum//deleted [Linux]
+{
 	#include "../qcommon/tags.h"
 };
 typedef char memtag_t;
@@ -3087,6 +3062,13 @@ String ID Tables
 ========================================================================
 */
 #define ENUM2STRING(arg)   { #arg,arg }
+/*
+typedef struct stringID_table_s
+{
+	char	*name;
+	int		id;
+} stringID_table_t;
+*/
 typedef struct stringID_table_s
 {
 	char	*name;
@@ -3106,10 +3088,11 @@ typedef enum
 	eForceReload_MODELS,
 	eForceReload_ALL
 
-} ForceReload_e;
+} ForceReload_e; //VOLGARENOK: need fix
 
 
-enum {
+enum
+{
 	FONT_NONE,
 	FONT_SMALL=1,
 	FONT_MEDIUM,

--- a/source/game/w_force.c
+++ b/source/game/w_force.c
@@ -24,9 +24,9 @@ extern qboolean GAME_INLINE WalkCheck( gentity_t * self );
 
 extern vmCvar_t		g_saberRestrictForce;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_FullBodyTauntAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern bot_state_t *botstates[MAX_CLIENTS];
 
@@ -930,9 +930,9 @@ void WP_SpawnInitForcePowers( gentity_t *ent )
 	//[/CoOp]
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_InKnockDown( int anim ); //bg_pmove.c
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 qboolean IsMerc(gentity_t*ent)
 {

--- a/source/game/w_saber.c
+++ b/source/game/w_saber.c
@@ -46,7 +46,7 @@ extern vmCvar_t		g_saberWallDamageScale;
 int saberSpinSound = 0;
 
 //would be cleaner if these were renamed to BG_ and proto'd in a header.
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean PM_SaberInTransition( int move );
 qboolean PM_SaberInDeflect( int move );
 qboolean PM_SaberInBrokenParry( int move );
@@ -59,7 +59,7 @@ qboolean BG_SaberInTransitionAny( int move );
 qboolean BG_SaberInAttackPure( int move );
 qboolean WP_SaberBladeUseSecondBladeStyle( saberInfo_t *saber, int bladeNum );
 qboolean WP_SaberBladeDoTransitionDamage( saberInfo_t *saber, int bladeNum );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void WP_SaberAddG2Model( gentity_t *saberent, const char *saberModel, qhandle_t saberSkin );
 void WP_SaberRemoveG2Model( gentity_t *saberent );
@@ -583,9 +583,9 @@ void SaberGotHit( gentity_t *self, gentity_t *other, trace_t *trace )
 	//Do something here..? Was handling projectiles here, but instead they're now handled in their own functions.
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SuperBreakLoseAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static GAME_INLINE void SetSaberBoxSize(gentity_t *saberent)
 {
@@ -1426,9 +1426,9 @@ int G_SaberLockAnim( int attackerSaberStyle, int defenderSaberStyle, int topOrSi
 	return baseAnim;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean BG_CheckIncrementLockAnim( int anim, int winOrLose ); //bg_saber.c
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 #define LOCK_IDEAL_DIST_JKA 46.0f//all of the new saberlocks are 46.08 from each other because Richard Lico is da MAN
 
 static GAME_INLINE qboolean WP_SabersCheckLock2( gentity_t *attacker, gentity_t *defender, sabersLockMode_t lockMode )
@@ -2346,10 +2346,10 @@ static GAME_INLINE int G_GetParryForBlock(int block)
 	return LS_NONE;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int PM_SaberBounceForAttack( int move );
 int PM_SaberDeflectionForQuad( int quad );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 extern stringID_table_t animTable[MAX_ANIMATIONS+1];
 //[RACC] - Determines the deflection animation for an attacking player.  Returns true if it 
@@ -5342,9 +5342,9 @@ void WP_SaberBounceSound( gentity_t *ent, int saberNum, int bladeNum )
 //This is a large function. I feel sort of bad inlining it. But it does get called tons of times per frame.
 //[SaberSys] moved this prototype up for ojp_SaberCanBlock
 /*
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SuperBreakWinAnim( int anim );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 */
 //[/SaberSys]
 
@@ -7108,9 +7108,9 @@ void G_SPSaberDamageTraceLerped( gentity_t *self, int saberNum, int bladeNum, ve
 */
 //[/SaberSys]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_SaberInTransitionAny( int move );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 qboolean WP_ForcePowerUsable( gentity_t *self, forcePowers_t forcePower );
 qboolean InFOV3( vec3_t spot, vec3_t from, vec3_t fromAngles, int hFOV, int vFOV );
@@ -8939,9 +8939,9 @@ qboolean saberCheckKnockdown_BrokenParry(gentity_t *saberent, gentity_t *saberOw
 	return qfalse;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 qboolean BG_InExtraDefenseSaberMove( int move );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //Called upon an enemy actually slashing into a thrown saber
 qboolean saberCheckKnockdown_Smashed(gentity_t *saberent, gentity_t *saberOwner, gentity_t *other, int damage)

--- a/source/game/w_saber.h
+++ b/source/game/w_saber.h
@@ -73,9 +73,9 @@ extern vmCvar_t g_MaxHolocronCarry;
 #define SABERMAXS_Z 3.0f//8.0f
 #define	SABER_MIN_THROW_DIST	80.0f
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int forcePowerNeeded[NUM_FORCE_POWER_LEVELS][NUM_FORCE_POWERS];
 extern float forceJumpHeight[NUM_FORCE_POWER_LEVELS];
 extern float forceJumpStrength[NUM_FORCE_POWER_LEVELS];
 extern float forcePushPullRadius[NUM_FORCE_POWER_LEVELS];
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/qcommon/disablewarnings.h
+++ b/source/qcommon/disablewarnings.h
@@ -10,21 +10,21 @@
 #pragma warning(disable : 4115)
 #pragma warning(disable : 4125)		// decimal digit terminates octal escape sequence
 #pragma warning(disable : 4127)		// conditional expression is constant
-#pragma warning(disable : 4136)
+//#pragma warning(disable : 4136)	//VOLGARENOK: no warning 4136
 #pragma warning(disable : 4152)		// nonstandard extension, function/data pointer conversion in expression
 #pragma warning(disable : 4201)
 #pragma warning(disable : 4214)
 #pragma warning(disable : 4244)		// conversion from double to float
-//#pragma warning(disable : 4284)		// return type not UDT
+//#pragma warning(disable : 4284)	// return type not UDT //VOLGARENOK: no warning 4284
 #pragma warning(disable : 4305)		// truncation from const double to float
 #pragma warning(disable : 4310)		// cast truncates constant value
 #pragma warning(disable : 4389)		// signed/unsigned mismatch
 #pragma warning(disable : 4503)		// decorated name length truncated
-//#pragma warning(disable:  4505)!!!remove these to reduce vm size!! // unreferenced local function has been removed
+//#pragma warning(disable:  4505)   !!! remove these to reduce vm size!! // unreferenced local function has been removed
 #pragma warning(disable : 4511)		//copy ctor could not be genned
 #pragma warning(disable : 4512)		//assignment op could not be genned
 #pragma warning(disable : 4514)		// unreffed inline removed
-//#pragma warning(disable : 4663)		// c++ lang change
+//#pragma warning(disable : 4663)	// c++ lang change //VOLGARENOK: no warning 4663
 #pragma warning(disable : 4702)		// unreachable code
 #pragma warning(disable : 4710)		// not inlined
 #pragma warning(disable : 4711)		// selected for automatic inline expansion

--- a/source/ui/ui.vcxproj
+++ b/source/ui/ui.vcxproj
@@ -157,6 +157,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/W4 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_Debug;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/source/ui/ui_force.c
+++ b/source/ui/ui_force.c
@@ -25,9 +25,9 @@ extern const char *UI_TeamName(int team);
 qboolean gTouchedForce = qfalse;
 vmCvar_t	ui_freeSaber, ui_forcePowerDisable;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void Menu_ShowItemByName(menuDef_t *menu, const char *p, qboolean bShow);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 int uiForceStarShaders[NUM_FORCE_STAR_IMAGES][2];
 int uiSaberColorShaders[NUM_SABER_COLORS];

--- a/source/ui/ui_local.h
+++ b/source/ui/ui_local.h
@@ -919,7 +919,7 @@ void UI_SPSkillMenu_Cache( void );
 // ui_syscalls.c
 //
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 void			trap_Print( const char *string );
 void			trap_Error( const char *string );
@@ -1016,7 +1016,7 @@ void			trap_CIN_SetExtents (int handle, int x, int y, int w, int h);
 int				trap_RealTime(qtime_t *qtime);
 void			trap_R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset );
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //
 // ui_addbots.c

--- a/source/ui/ui_main.c
+++ b/source/ui/ui_main.c
@@ -307,7 +307,7 @@ void UI_ReaAllocMem(void **ptr, int sze, int count);
 char *UI_GetSaberHiltInfo(qboolean TwoHanded, int index);
 //[/DynamicMemory_Sabers]
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 // Functions in BG or ui_shared
 void Menu_ShowGroup (menuDef_t *menu, char *itemName, qboolean showFlag);
 void Menu_ItemDisable(menuDef_t *menu, char *name,int disableFlag);
@@ -370,7 +370,7 @@ int vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int a
 
 	return -1;
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 siegeClassDesc_t g_UIClassDescriptions[MAX_SIEGE_CLASSES];
 siegeTeam_t *siegeTeam1 = NULL;
@@ -384,10 +384,10 @@ int g_UIGloballySelectedSiegeClass = -1;
 qboolean	UIPAFtextLoaded = qfalse;
 animation_t	uiHumanoidAnimations[MAX_TOTALANIMATIONS]; //humanoid animations are the only ones that are statically allocated.
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 bgLoadedAnim_t bgAllAnims[MAX_ANIM_FILES];
 int uiNumAllAnims = 1; //start off at 0, because 0 will always be assigned to humanoid.
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 animation_t *UI_AnimsetAlloc(void)
 {
@@ -487,7 +487,7 @@ models/players/visor/animation.cfg, etc
 
 ======================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 static char UIPAFtext[60000];
 int UI_ParseAnimationFile(const char *filename, animation_t *animset, qboolean isHumanoid) 
 {
@@ -693,7 +693,7 @@ int UI_ParseAnimationFile(const char *filename, animation_t *animset, qboolean i
 //menuDef_t *Menus_FindByName(const char *p);
 void Menu_ShowItemByName(menuDef_t *menu, const char *p, qboolean bShow);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 void UpdateForceUsed();
 
@@ -903,7 +903,7 @@ void _UI_DrawRect( float x, float y, float width, float height, float size, cons
 	trap_R_SetColor( NULL );
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int MenuFontToHandle(int iMenuFont)
 {
 	switch (iMenuFont)
@@ -916,7 +916,7 @@ int MenuFontToHandle(int iMenuFont)
 
 	return uiInfo.uiDC.Assets.qhMediumFont;	// 0;
 }
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 int Text_Width(const char *text, float scale, int iMenuFont) 
 {	
@@ -1074,9 +1074,9 @@ static void UI_BuildPlayerList();
 /* not used in basejka code
 //char parsedFPMessage[1024];
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern int FPMessageTime;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 */
 //[/UITweaks]
 
@@ -1280,9 +1280,9 @@ void _UI_Refresh( int realtime )
 _UI_Shutdown
 =================
 */
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void UI_CleanupGhoul2(void);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[DynamicMemory_Sabers]
 void UI_FreeSabers(void);
@@ -3946,9 +3946,9 @@ static qboolean UI_Effects_HandleKey(int flags, float *special, int key) {
 	return qfalse;
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern void	Item_RunScript(itemDef_t *item, const char *s);		//from ui_shared;
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 // For hot keys on the chat main menu.
 static qboolean UI_Chat_Main_HandleKey(int key) 
@@ -5872,10 +5872,10 @@ static void UI_SetSaberBoxesandHilts (void)
 
 //extern qboolean UI_SaberModelForSaber( const char *saberName, char *saberModel );
 extern qboolean UI_SaberSkinForSaber( const char *saberName, char *saberSkin );
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean ItemParse_asset_model_go( itemDef_t *item, const char *name,int *runTimeLength );
 extern qboolean ItemParse_model_g2skin_go( itemDef_t *item, const char *skinName );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static void UI_UpdateSaberType( void )
 {
@@ -6042,9 +6042,9 @@ static void UI_GetSaberCvars ( void )
 
 
 //extern qboolean ItemParse_model_g2skin_go( itemDef_t *item, const char *skinName );
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 extern qboolean ItemParse_model_g2anim_go( itemDef_t *item, const char *animName );
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 //extern qboolean ItemParse_asset_model_go( itemDef_t *item, const char *name );
 
 void UI_UpdateCharacterSkin( void )
@@ -7530,9 +7530,9 @@ static void UI_RunMenuScript(char **args)
 static void UI_GetTeamColor(vec4_t *color) {
 }
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 int BG_SiegeCountBaseClass(const int team, const short classIndex);
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 static void UI_SiegeClassCnt( const int team )
 {

--- a/source/ui/ui_shared.c
+++ b/source/ui/ui_shared.c
@@ -46,7 +46,7 @@ extern void UI_CacheSaberGlowGraphics( void );
 
 #endif //
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 #ifdef CGAME
 
@@ -5454,9 +5454,9 @@ void UI_ScaleModelAxis(refEntity_t	*ent)
 }
 
 #ifndef CGAME
-#include "../namespace_end.h"	// Yes, these are inverted. The whole file is in the namespace.
+//#include "../namespace_end.h" //VOLGARENOK: deprecated	// Yes, these are inverted. The whole file is in the namespace.
 extern void UI_SaberAttachToChar( itemDef_t *item );
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 #endif
 
 void Item_Model_Paint(itemDef_t *item) 
@@ -9766,4 +9766,4 @@ static qboolean Menu_OverActiveItem(menuDef_t *menu, float x, float y) {
 	return qfalse;
 }
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated

--- a/source/ui/ui_shared.h
+++ b/source/ui/ui_shared.h
@@ -472,7 +472,7 @@ typedef struct {
 
 } displayContextDef_t;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 
 const char *String_Alloc(const char *p);
 void String_Init();
@@ -612,7 +612,7 @@ qboolean	trap_G2API_IKMove(void *ghoul2, int time, sharedIKMoveParams_t *params)
 
 void		trap_G2API_GetSurfaceName(void *ghoul2, int surfNumber, int modelIndex, char *fillBuf);
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated
 
 //[NewUI]
 typedef struct

--- a/source/ui/ui_syscalls.c
+++ b/source/ui/ui_syscalls.c
@@ -7,7 +7,7 @@
 
 static int (QDECL *syscall)( int arg, ... ) = (int (QDECL *)( int, ...))-1;
 
-#include "../namespace_begin.h"
+//#include "../namespace_begin.h" //VOLGARENOK: deprecated
 void dllEntry( int (QDECL *syscallptr)( int arg,... ) ) {
 	syscall = syscallptr;
 }
@@ -666,4 +666,4 @@ qboolean trap_G2API_AttachG2Model(void *ghoul2From, int modelIndexFrom, void *gh
 Ghoul2 Insert End
 */
 
-#include "../namespace_end.h"
+//#include "../namespace_end.h" //VOLGARENOK: deprecated


### PR DESCRIPTION
Fix warnings:
1)Commented smth in disablewarning.h
2)Commented all inlcude begin/end
3)Fixes in q_shared.h. Unified "typedef enum" for almost enums.
